### PR TITLE
Change ls options to '-xr' to stop nondeterministic deploy:rollback behavior.

### DIFF
--- a/lib/railsless-deploy.rb
+++ b/lib/railsless-deploy.rb
@@ -51,7 +51,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:current_path)      { File.join(deploy_to, current_dir) }
   _cset(:release_path)      { File.join(releases_path, release_name) }
 
-  _cset(:releases)          { capture("ls -xt #{releases_path}").split.reverse }
+  _cset(:releases)          { capture("ls -xr #{releases_path}").split.reverse }
   _cset(:current_release)   { File.join(releases_path, releases.last) }
   _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 

--- a/lib/railsless-deploy.rb
+++ b/lib/railsless-deploy.rb
@@ -28,6 +28,8 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:deploy_to) { "/u/apps/#{application}" }
   _cset(:revision)  { source.head }
 
+_cset(:ls_opts) { "-xt" }
+
   # =========================================================================
   # These variables should NOT be changed unless you are very confident in
   # what you are doing. Make sure you understand all the implications of your
@@ -51,7 +53,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:current_path)      { File.join(deploy_to, current_dir) }
   _cset(:release_path)      { File.join(releases_path, release_name) }
 
-  _cset(:releases)          { capture("ls -xr #{releases_path}").split.reverse }
+  _cset(:releases)          { capture("ls #{ls_opts} #{releases_path}").split.reverse }
   _cset(:current_release)   { File.join(releases_path, releases.last) }
   _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 


### PR DESCRIPTION
Lee:

We use rsync to deploy code, and it leaves the timestamps all screwy for reasons I can't quite figure, so 'ls -xt' doesn't produce correct results, while 'ls -xr' does.

I understand if this patch won't product correct behavior for people who name their releases differently. If that's the case, please reject it, but would it make sense to provide some user-visible setting to alter the ls options? That seems like a more correct choice, but it's more than a 1-character change. =)

Chris

---

Change ls options from -xt to -xr, which fixes nondeterministic rollback behavior when our releases are named 20110404210241 (YYYYMMDDHHMMSS) but our modification times are unreliable (apparently because of rsync). Best thing would be to have the ls options be user-settable.
