### PR TITLE
Update Readme; Replace Deprecated Task

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,21 +28,21 @@ You should then be able to proceed as you would usually, you may want to familia
 
 If you want to try before you buy, here's the list of tasks included with this version of the deploy recipe:
 
-    cap deploy               # Deploys your project.
-    cap deploy:check         # Test deployment dependencies.
-    cap deploy:cleanup       # Clean up old releases.
-    cap deploy:cold          # Deploys and starts a `cold' application.
-    cap deploy:pending       # Displays the commits since your last deploy.
-    cap deploy:pending:diff  # Displays the `diff' since your last deploy.
-    cap deploy:rollback      # Rolls back to a previous version and restarts.
-    cap deploy:rollback:code # Rolls back to the previously deployed version.
-    cap deploy:setup         # Prepares one or more servers for deployment.
-    cap deploy:symlink       # Updates the symlink to the most recently deployed ...
-    cap deploy:update        # Copies your project and updates the symlink.
-    cap deploy:update_code   # Copies your project to the remote servers.
-    cap deploy:upload        # Copy files to the currently deployed version.
-    cap invoke               # Invoke a single command on the remote servers.
-    cap shell                # Begin an interactive Capistrano session.
+    cap deploy                # Deploys your project.
+    cap deploy:check          # Test deployment dependencies.
+    cap deploy:cleanup        # Clean up old releases.
+    cap deploy:cold           # Deploys and starts a `cold' application.
+    cap deploy:pending        # Displays the commits since your last deploy.
+    cap deploy:pending:diff   # Displays the `diff' since your last deploy.
+    cap deploy:rollback       # Rolls back to a previous version and restarts.
+    cap deploy:rollback:code  # Rolls back to the previously deployed version.
+    cap deploy:setup          # Prepares one or more servers for deployment.
+    cap deploy:create_symlink # Updates the symlink to the most recently deployed ...
+    cap deploy:update         # Copies your project and updates the symlink.
+    cap deploy:update_code    # Copies your project to the remote servers.
+    cap deploy:upload         # Copy files to the currently deployed version.
+    cap invoke                # Invoke a single command on the remote servers.
+    cap shell                 # Begin an interactive Capistrano session.
 
 
 ## Bugs & Feedback


### PR DESCRIPTION
Update list of tasks; replaced deprecated symlink with create_symlink

according to #12 ( [lib/railsless-deploy L249-253](https://github.com/leehambley/railsless-deploy/blob/master/lib/railsless-deploy.rb#L249-L253)) symlink has been deprecated
