### PR TITLE
Check for existence of any releases before setting current_release

### DIFF
--- a/lib/railsless-deploy.rb
+++ b/lib/railsless-deploy.rb
@@ -52,7 +52,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:release_path)      { File.join(releases_path, release_name) }
 
   _cset(:releases)          { capture("ls -xt #{releases_path}").split.reverse }
-  _cset(:current_release)   { File.join(releases_path, releases.last) }
+  _cset(:current_release)   { releases.any? ? File.join(releases_path, releases.last) : nil }
   _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 
   _cset(:current_revision)  { capture("cat #{current_path}/REVISION").chomp }


### PR DESCRIPTION
Releases directory exists in the environment as an empty directory. Before patch, running deploy:setup() would throw "`join': can't convert nil into String" type error. After patch, current_release is set to nil and allows the task to complete.
