### PR TITLE
Heed use_sudo setting for deploy:rollback:cleanup

### DIFF
--- a/lib/railsless-deploy.rb
+++ b/lib/railsless-deploy.rb
@@ -318,7 +318,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         (if ever) need to be called directly.
       DESC
       task :cleanup, :except => { :no_release => true } do
-        run "if [ `readlink #{current_path}` != #{current_release} ]; then rm -rf #{current_release}; fi"
+        run "if [ `readlink #{current_path}` != #{current_release} ]; then #{try_sudo} rm -rf #{current_release}; fi"
       end
 
       desc <<-DESC


### PR DESCRIPTION
Without this, cleanup fails on servers that need sudo for cleaning
caches, etc.
