### PR TITLE
Bug Fix: releases can be out of order which causes a deletion of newer r...

### DIFF
--- a/lib/railsless-deploy.rb
+++ b/lib/railsless-deploy.rb
@@ -51,7 +51,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:current_path)      { File.join(deploy_to, current_dir) }
   _cset(:release_path)      { File.join(releases_path, release_name) }
 
-  _cset(:releases)          { capture("ls -xt #{releases_path}").split.reverse }
+ _cset(:releases)          { capture("#{try_sudo} ls -x #{releases_path}", :except => { :no_release => true }).split.sort }
   _cset(:current_release)   { releases.any? ? File.join(releases_path, releases.last) : nil }
   _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 


### PR DESCRIPTION
releases can be out of order which causes a deletion of newer releases. this happens if an older release folders last modified time is older than a new release (it does happen). in the case where you only keep 1 release it will remove the only release that current is linking to.

using Capistrano's code to get releases solves this probablem (since it sorts the releases by name instead of last modified time) https://github.com/capistrano/capistrano/blob/master/lib/capistrano/recipes/deploy.rb#L380
